### PR TITLE
Update 50-shades-of-golang-traps

### DIFF
--- a/50-shades-of-golang-traps-gotchas-mistakes.md
+++ b/50-shades-of-golang-traps-gotchas-mistakes.md
@@ -1308,7 +1308,6 @@ func main() {
 	}
 
 	checkError(err)
-	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	checkError(err)


### PR DESCRIPTION
fix bug in example code.

http://devs.cloudimmunity.com/gotchas-and-common-mistakes-in-go-golang/
